### PR TITLE
Run superset on parquet files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,21 @@ meltano run superset:ui
 
    - SQL Alchemy URL: ```duckdb:////tmp/mdsbox.db```
 
-   - Advanced Settings > Other > Engine Parameters: ```{"connect_args":{"read_only":true}}```
+   - Advanced Settings > SQL Lab > ✔ Expose Database in SQL Lab > ✔ Allow CREATE VIEW AS & ✔ Allow this database to be explored & ✔ Allow DML
+
+   - Since the dbt run is materialized to `.parquet` files only, to make the tables available in Superset, go to SQL Lab > SQL Editor and run:
+   
+       ```c
+       CREATE VIEW initialized_seeding as SELECT * FROM read_parquet('/tmp/data_catalog/conformed/initialize_seeding.parquet');
+       CREATE VIEW playoff_sim_r1 as SELECT * FROM read_parquet('/tmp/data_catalog/conformed/playoff_sim_r1.parquet');
+       CREATE VIEW playoff_sim_r2 as SELECT * FROM read_parquet('/tmp/data_catalog/conformed/playoff_sim_r2.parquet');
+       CREATE VIEW playoff_sim_r3 as SELECT * FROM read_parquet('/tmp/data_catalog/conformed/playoff_sim_r3.parquet');
+       CREATE VIEW playoff_sim_r4 as SELECT * FROM read_parquet('/tmp/data_catalog/conformed/playoff_sim_r4.parquet');
+       CREATE VIEW reg_season_summary as SELECT * FROM read_parquet('/tmp/data_catalog/conformed/reg_season_summary.parquet');
+       CREATE VIEW season_summary as SELECT * FROM read_parquet('/tmp/data_catalog/conformed/season_summary.parquet');
+       CREATE VIEW reg_season_end as SELECT * FROM read_parquet('/tmp/data_catalog/conformed/reg_season_end.parquet');
+       ```
+
 
 7. Explore your data inside superset. Go to SQL Labs > SQL Editor and write a custom query. A good example is ```SELECT * FROM reg_season_end```.
 

--- a/meltano.yml
+++ b/meltano.yml
@@ -58,7 +58,7 @@ plugins:
   utilities:
     - name: superset
       variant: apache
-      pip_url: apache-superset>=1.5.0
+      pip_url: apache-superset>=1.5.0 markupsafe==2.0.1 Werkzeug==2.0.3 WTForms==2.3.0 duckdb-engine==0.6.4
       config:
         ENABLE_PROXY_FIX: true
     - name: dbt-duckdb


### PR DESCRIPTION
Following the conversation in Issue #39 , I investigated how to run Superset directly from the parquet external output from dbt. It looks like there's no built-in support to directly run from files - you still need to have a database engine running to make use of data in .csv or .parquet files.

This branch captures the steps made to get the full demo running this way. Did it for my own edification, but offering it as a PR in case you want to update the main repo to be a fully working example. Since it's for temporary purposes only, totally fine if you'd rather not merge it. 

Two changes:

- Superset was throwing errors when installed as Superset>=1.5.0 (changed from an == in the latest merge), and superset's dependencies weren't getting installed right. Added explicit dependencies for Superset to meltano.yml to get it running without error on Codespaces 
- Update readme.md to capture steps taken in Superset to run off of views of the parquet files
   - Recognizing the block of SQL to copy is pretty ugly, but figured it can work as a short-term workaround.

**Note**: Initial plan was to run `:memory:` DuckDB database, rather than instantiate it as a file. Superset seems to create new "connections" to independent instances of duckdb in-memory databases in each SQL query window, and in dataset creation modal. So even though the view creations ran successfully, any other window to the DB didn't see those views. Specifying a `.db` file solved that issue. And Superset DuckDB created the file on first connection, so no problem that it didn't exist. I removed the instruction to open the DB in read only mode, so the views could be created. Didn't run into any subsequent locking issues while testing from Superset, so I think it's ok to leave that out, even after view creation.
