### PR TITLE
add DinD feature to devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,6 +35,10 @@
         "vivaxy.vscode-conventional-commits",
         "mechatroner.rainbow-csv"
     ],
+    "features": {
+        //see https://github.com/devcontainers/features/tree/main/src/docker-in-docker for details on below
+        "ghcr.io/devcontainers/features/docker-in-docker:1":{}
+    },
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9
 
-WORKDIR /usr/src/app
+WORKDIR /workspaces/nba-monte-carlo
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
   && wget https://github.com/duckdb/duckdb/releases/download/v0.5.1/duckdb_cli-linux-amd64.zip && unzip duckdb_cli-linux-amd64.zip \
   && pip install --no-cache-dir meltano==2.10.0
 
-COPY meltano.yml /usr/src/app/
+COPY meltano.yml ./
 
 RUN meltano --log-level=debug --environment=docker install extractors
 RUN meltano --log-level=debug --environment=docker install loaders

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ docker-build:
 
 docker-run:
 	docker run \
+		--publish 8088:8088 \
 	 	--env MELTANO_CLI_LOG_LEVEL=WARNING \
-		--env MDS_SCENARIOS=100 \
+		--env MDS_SCENARIOS=1000 \
 		--env MDS_INCLUDE_ACTUALS=true \
 		--env MDS_LATEST_RATINGS=true \
 		--env MDS_ENABLE_EXPORT=true \
-		mdsbox make pipeline
+		mdsbox make pipeline superset-visuals 
 ```
 
 You can then scale out to Kubernetes, assuming you have it installed:
@@ -70,6 +71,31 @@ You can then scale out to Kubernetes, assuming you have it installed:
 kubectl apply -f ./kubernetes/pod.yaml
 ```
 
+## Using GitHub Codespaces
+
+Want to try MDS in a Box right away? Create a Codespace:
+
+![image](https://user-images.githubusercontent.com/79663385/204594948-1d50a7f2-b17f-4cb8-b8d4-7659cd526dd5.png)
+
+You can run in the Codespace two ways:
+
+1. Directly in the Codespaces development environment:
+
+	```
+	make build pipeline superset-visuals
+	```
+	
+2. Or using Docker inside the Codespace:
+
+	```
+	make docker-build docker-run
+	```
+
+In both cases, you will need to wait for the pipeline to run and Superset configuration to complete. 
+
+You can then access the Superset dashboard by clicking on the Open in Browswer button on the Ports tab:
+![image](https://user-images.githubusercontent.com/79663385/204596948-64cac757-cbaf-434d-ab65-327b8ed8f043.png)
+and log in with the username and password: "admin" and "password".
 
 ## Using Parquet instead of a database
 This project leverages parquet instead of a database for file storage. This is experimental and implementation will evolve over time.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,33 @@ Right now, you can get the nba schedule and elo ratings from this project and ge
 ![image](https://user-images.githubusercontent.com/16811433/195012880-adf8da03-ab16-4c16-8080-95514fb41c21.png)
 ![image](https://user-images.githubusercontent.com/16811433/195012951-dde884a0-88f5-48d5-8203-b6f06ba7dbd4.png)
 
-## Getting started - Windows
+## Using GitHub Codespaces
+
+Want to try MDS in a Box right away? Create a Codespace:
+
+![image](https://user-images.githubusercontent.com/79663385/204594948-1d50a7f2-b17f-4cb8-b8d4-7659cd526dd5.png)
+
+You can run in the Codespace two ways:
+
+1. Directly in the Codespaces development environment:
+
+	```
+	make build pipeline superset-visuals
+	```
+	
+2. Or using Docker inside the Codespace:
+
+	```
+	make docker-build docker-run
+	```
+
+In both cases, you will need to wait for the pipeline to run and Superset configuration to complete. 
+
+You can then access the Superset dashboard by clicking on the Open in Browswer button on the Ports tab:
+![image](https://user-images.githubusercontent.com/79663385/204596948-64cac757-cbaf-434d-ab65-327b8ed8f043.png)
+and log in with the username and password: "admin" and "password".
+
+## Building MDS in a box in Windows
 1. Create your WSL environment. Open a PowerShell terminal running as an administrator and execute:
 ```
 wsl --install
@@ -71,34 +97,8 @@ You can then scale out to Kubernetes, assuming you have it installed:
 kubectl apply -f ./kubernetes/pod.yaml
 ```
 
-## Using GitHub Codespaces
-
-Want to try MDS in a Box right away? Create a Codespace:
-
-![image](https://user-images.githubusercontent.com/79663385/204594948-1d50a7f2-b17f-4cb8-b8d4-7659cd526dd5.png)
-
-You can run in the Codespace two ways:
-
-1. Directly in the Codespaces development environment:
-
-	```
-	make build pipeline superset-visuals
-	```
-	
-2. Or using Docker inside the Codespace:
-
-	```
-	make docker-build docker-run
-	```
-
-In both cases, you will need to wait for the pipeline to run and Superset configuration to complete. 
-
-You can then access the Superset dashboard by clicking on the Open in Browswer button on the Ports tab:
-![image](https://user-images.githubusercontent.com/79663385/204596948-64cac757-cbaf-434d-ab65-327b8ed8f043.png)
-and log in with the username and password: "admin" and "password".
-
 ## Using Parquet instead of a database
-This project leverages parquet instead of a database for file storage. This is experimental and implementation will evolve over time.
+This project leverages parquet in addition to a database for file storage. This is experimental and implementation will evolve over time.
 
 ## Todos
 - [x] replace reg season schedule with 538 schedule

--- a/meltano.yml
+++ b/meltano.yml
@@ -9,8 +9,8 @@ environments:
       TMP_PATH: /tmp
   - name: docker
     env:
-      MELTANO_PROJECT_ROOT: /usr/src/app
-      TMP_PATH: /usr/src/app/tmp
+      MELTANO_PROJECT_ROOT: /workspaces/nba-monte-carlo
+      TMP_PATH: /workspaces/nba-monte-carlo/tmp
   - name: prod
     env:
       TMP_PATH: /tmp


### PR DESCRIPTION
Saw your tweet about getting it running in Docker locally, and thought: Why not CodeSpaces?

This PR adds the docker-in-docker feature to the codespace (docker-in-docker since CodeSpaces itself runs in a container). It is NOT yet in a finished working state.

As-is, on Codespaces, the container successfully builds, pipeline runs, and Superset starts up. But it throws an error when you open the dashboard:
![image](https://user-images.githubusercontent.com/79663385/204542021-5652c5ae-c9bb-46dc-a141-1bd0b7821fc3.png)

It looks like there's some alignment needed between where the db file gets saved inside the container (`/usr/src/app/data/data_catalog/mdsbox.db`) and where Superset expects to find it (`/workspaces/nba-monte-carlo/data/data_catalog/mdsbox.db`).

Is that already fixed in your local branch? I can proceed to get that sorted on my branch if it helps.