### PR TITLE
Adding Rill as a visualization option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,30 @@ docker-run-evidence:
 		--env MDS_ENABLE_EXPORT=true \
 		--env ENVIRONMENT=docker \
 		mdsbox make pipeline evidence-visuals
+
+rill-install:
+	curl -s https://cdn.rilldata.com/install.sh | bash
+
+rill-build:
+	mkdir -p rill
+	cd rill && rill init
+	cd rill && for file in ../data/data_catalog/conformed/*.parquet; do rill source add $$file; done
+
+rill-run:
+	cd rill && rill start
+
+rill-visuals:
+	make rill-install
+	make rill-build
+	make rill-run
+
+docker-run-rill:
+		docker run \
+		--publish 9009:9009 \
+	 	--env MELTANO_CLI_LOG_LEVEL=WARNING \
+		--env MDS_SCENARIOS=10000 \
+		--env MDS_INCLUDE_ACTUALS=true \
+		--env MDS_LATEST_RATINGS=true \
+		--env MDS_ENABLE_EXPORT=true \
+		--env ENVIRONMENT=docker \
+		mdsbox make pipeline rill-visuals	


### PR DESCRIPTION
In the latest release of Rill that came out this week, they now persist everything to yaml/sql files. [Rill 0.16 release notes](https://docs.rilldata.com/notes/0.16)

I've been meaning to try out Rill, and thought the persistent configuration would be a good hook for *yet another* visualization method in MDSiaB. (if it makes it too cluttered, and you'd rather not merge, no worries. I'll keep it in my own fork.)

This PR is an MVP to get it up and running. My initial plan was to use the duckdb `.db` file to pre-load the data in Rill. It's not well documented in the Rill docs, but looks like there's a command line hook with a `--db` flag to do exactly that. However, I couldn't get that working on first pass. Not sure if a duckdb version mismatch (I think they're using 0.6.0 at the moment) or if there's extra config details that need to be added to the db first. So for now, just individually loading all the parquet files.

Future plans would be to define and persist a few dashboards, and figure out and document the workflow for using Rill for EDA. Didn't want to update the readme until some of that was done.