### PR TITLE
Remove `sudo` from `uv` configuration

### DIFF
--- a/.github/workflows/pr_to_master.yml
+++ b/.github/workflows/pr_to_master.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@master
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
           python-version: '3.11'
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 install-uv:
-	sudo pip install uv
-	sudo uv pip install --system -r requirements.txt
+	pip install uv
+	uv pip install --system -r requirements.txt
 
 build: install-uv
-	cd transform && sudo dbt deps
+	cd transform && dbt deps
 	cd evidence && npm install
 	mkdir -p data/data_catalog/raw
 	mkdir -p data/data_catalog/prep
@@ -12,7 +12,7 @@ build: install-uv
 
 run:
 	cd dlt && python3 nba_pipeline.py
-	cd transform && sudo dbt build
+	cd transform && dbt build
 	cd evidence && npm run sources
 
 dev:


### PR DESCRIPTION
## Summary

It looks like the issue here is that the workflow was missing `actions/setup-python`. Without it, I think the workflow has access to Python in the "tool cache" but that it's like... not fully configured? So you don't have write permissions to it?

`pip` has a behavior whereby if you try to install, and you don't have permissions to write, it falls back to a slightly different setup (as if you ran `pip install --user`). We don't have that behavior in `uv`. But if you use `setup-python` (is 0 seconds anyway), then the workflow will have the expected permissions, and `uv pip install --system` works without `sudo`.

## Test Plan

- Ran to completion here: https://github.com/charliermarsh/nba-monte-carlo/pull/1
- Ran `docker build .` locally
