### PR TITLE
fix: add dlt repo copy to the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
   && wget https://github.com/duckdb/duckdb/releases/download/v0.9.1/duckdb_cli-linux-amd64.zip && unzip duckdb_cli-linux-amd64.zip
 
 COPY data ./data
+COPY dlt ./dlt
 COPY transform ./transform
 COPY Makefile .
 COPY evidence ./evidence


### PR DESCRIPTION
The `docker-run-evidence` command does a `mdsbox make run serve`.

The `run` part `cd` into the `dlt` folder, but it was never copied in the Dockerfile, thus generating an error.